### PR TITLE
Update footer.tpl to fix footer error with php 7.x

### DIFF
--- a/template/footer.tpl
+++ b/template/footer.tpl
@@ -17,7 +17,7 @@
 </div>
 {/if}
 {footer_script require='jquery'}
-document.cookie = 'screen_size='+jQuery(document).width()+'x'+jQuery(document).height()+';path={isset($COOKIE_PATH) ? $COOKIE_PATH : ''}';
+document.cookie = 'screen_size='+jQuery(document).width()+'x'+jQuery(document).height()+';path={$COOKIE_PATH|default:''}';
 {/footer_script}
 {get_combined_scripts load='footer'}
 {if isset($footer_elements)}


### PR DESCRIPTION
The prior version threw errors with PHP 7.0.33 and made the whole photos in an album not being shown. I propose to use this syntax https://www.smarty.net/docs/en/tips.default.var.handling.tpl - it works for my setup with php 7.0.33, but I cannot test with  PHP8 and I am not a trained developer. I hope this helps.